### PR TITLE
Update homepage to say 'Welcome to the best repo'

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ export default function Home() {
           height={38}
           priority
         />
+        <h1 className="text-3xl font-bold text-center mb-8">Welcome to the best repo</h1>
         <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
           <li className="mb-2 tracking-[-.01em]">
             Get started by editing{" "}


### PR DESCRIPTION
The homepage now displays 'Welcome to the best repo' as a header above the instructions list.